### PR TITLE
Pcode nop fix

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,7 @@
+/.gradle/
+.classpath
+.project
+.settings/
+bin/
+build/
+dist/

--- a/src/main/java/ghidra/pal/cfg/PcodeOpProvider.java
+++ b/src/main/java/ghidra/pal/cfg/PcodeOpProvider.java
@@ -23,15 +23,18 @@ public class PcodeOpProvider<T extends Instruction> implements CFGVertexDetailPr
 		
 	// Common method to compute the location for the fall-through.
 	Pair<Address,Integer> getFallthruLoc(Pair<Address,Integer> curLoc, Instruction insn) {
-		int pcodeLen = insn.getPcode().length;
-		int insnLen = insn.getLength();
 		int nextLoc = curLoc.y+1;
+		Address nextAddr = curLoc.x;
 		// If we've reached the end of the pcode for this Instruction, move on
 		// to the next one.
-		if(nextLoc >= pcodeLen)
-			return new Pair<Address,Integer>(curLoc.x.addWrap(insnLen),0);
+		
+		while (nextLoc >= insn.getPcode().length) { // handle nops (like in AARCH64)
+			nextLoc = 0;
+			nextAddr = nextAddr.addWrap(insn.getLength());
+			insn = Cache.getInstruction(nextAddr);
+		}
 		// Otherwise, increment the pcode index and return a new location.
-		return new Pair<Address,Integer>(curLoc.x, nextLoc);
+		return new Pair<Address,Integer>(nextAddr, nextLoc);
 	}
 	
 	// Common method to compute the location for the taken destination. 


### PR DESCRIPTION
Fixes behaviour for getFallthruLoc to handle architectures which have nop instructions.

See Pcode from a simple aarch64 binary:
![figurë](https://user-images.githubusercontent.com/10711159/87270815-eb4c3500-c496-11ea-9ceb-70f68b82d174.png)

Before changes, this would cause the cfg builder to assume that disassembly failed (and ultimately cause a NPE without my other PR).

Fixes for instructions with 0 length, alternatively you could choose to use #7. AFAIK, you only need one of these pull requests to fix this problem. Just close the other, up to you.