### PR TITLE
Pcode bounds fix

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,7 @@
+/.gradle/
+.classpath
+.project
+.settings/
+bin/
+build/
+dist/

--- a/src/main/java/ghidra/pal/cfg/PcodeOpProvider.java
+++ b/src/main/java/ghidra/pal/cfg/PcodeOpProvider.java
@@ -112,7 +112,7 @@ public class PcodeOpProvider<T extends Instruction> implements CFGVertexDetailPr
 		
 		// If the location is not within the PcodeOp block, return null.
 		PcodeOp[] pcode = instr.getPcode();
-		if(addr.y > pcode.length)
+		if(addr.y >= pcode.length)
 			return null;
 		
 		// Get the PcodeOp, its Raw counterpart, and behavior.


### PR DESCRIPTION
Just a bad bounds check. Fixes for instructions with 0 length, alternatively you could choose to use #6. AFAIK, you only need one of these pull requests to fix this problem. Just close the other.